### PR TITLE
UPDATE: modified viewing of statuses

### DIFF
--- a/app/(auth)/(navigation)/groups/[groupID]/statuses/page.tsx
+++ b/app/(auth)/(navigation)/groups/[groupID]/statuses/page.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { GroupDetailsType } from "@/src/components/groups/custom/GroupMembers";
+import { GroupStatusType } from "@/src/components/groups/custom/GroupStrengthSection";
+import FullStatusList from "@/src/components/groups/custom/statuses/FullStatusList";
+import HeaderBar from "@/src/components/navigation/HeaderBar";
+import RestrictedScreen from "@/src/components/screens/RestrictedScreen";
+import SignInAgainScreen from "@/src/components/screens/SignInAgainScreen";
+import { GetPostObj } from "@/src/utils/API/GetPostObj";
+import ErrorScreenHandler from "@/src/utils/ErrorScreenHandler";
+import { GROUP_ROLES_HEIRARCHY } from "@/src/utils/constants";
+import { GROUP_MEMBERS_SCHEMA } from "@/src/utils/schemas/groups";
+import { cookies } from "next/headers";
+
+export default async function Page({
+  params,
+}: {
+  params: { [groupID: string]: string };
+}) {
+  const groupID = params.groupID;
+  const cookieStore = cookies();
+
+  const data = cookieStore.get("memberID");
+
+  if (data) {
+    const memberID = data.value;
+
+    try {
+      const host = process.env.HOST;
+
+      const PostObj = GetPostObj({ groupID });
+      // check if member is in group
+      const groupPostObj = GetPostObj({ groupID, memberID });
+      const res = await fetch(`${host}/api/groups/memberof`, groupPostObj);
+      const body = await res.json();
+      if (!body.status) return <RestrictedScreen />;
+
+      const currentMember = body.data as GROUP_MEMBERS_SCHEMA;
+      const { role } = currentMember;
+      const admin =
+        GROUP_ROLES_HEIRARCHY[role].rank >= GROUP_ROLES_HEIRARCHY["admin"].rank;
+
+      if (!admin) return <RestrictedScreen />;
+
+      // get group members
+      const resB = await fetch(`${host}/api/groups/members`, PostObj);
+      const bodyB = await resB.json();
+
+      if (!bodyB.status) throw new Error(bodyB.error);
+      const groupMembers = bodyB.data as GroupDetailsType;
+
+      // get group statuses
+      const memberIDList = Object.keys(groupMembers);
+      const to_send = {
+        groupID: groupID,
+        list: memberIDList,
+      };
+
+      const StatusObj = GetPostObj(to_send);
+      const resC = await fetch(`${host}/api/groups/statuses`, StatusObj);
+      const bodyC = await resC.json();
+
+      if (!bodyC.status) throw new Error(bodyC.error);
+
+      const groupStatusList = {} as GroupStatusType;
+
+      const dataC = bodyC.data as any[];
+
+      dataC.forEach((item: any) => {
+        // handle group members
+        const data = item.data;
+        const memberID = Object.keys(data)[0];
+        const memberStatusObj = data[memberID];
+        groupStatusList[memberID] = memberStatusObj;
+      });
+
+      let sortedIDs = Object.keys(groupStatusList).sort(
+        (a: string, b: string) => {
+          return Object.keys(groupStatusList[a]).length >
+            Object.keys(groupStatusList[b]).length
+            ? -1
+            : 1;
+        }
+      );
+
+      const sortedGroupStatusList = {} as GroupStatusType;
+
+      sortedIDs.forEach((id: string) => {
+        sortedGroupStatusList[id] = groupStatusList[id];
+      });
+
+      return (
+        <>
+          <HeaderBar back text={`All Statuses`} />
+          <div className="grid place-items-center">
+            <div className="max-w-[500px] w-full">
+              <div className="flex flex-col items-center justify-start w-full gap-4">
+                <FullStatusList groupStatusList={sortedGroupStatusList} />
+              </div>
+            </div>
+          </div>
+        </>
+      );
+    } catch (err: any) {
+      return ErrorScreenHandler(err);
+    }
+  }
+  return <SignInAgainScreen />;
+}

--- a/src/components/groups/custom/GroupStrengthSection.tsx
+++ b/src/components/groups/custom/GroupStrengthSection.tsx
@@ -10,6 +10,7 @@ import { twMerge } from "tailwind-merge";
 import { GROUP_MEMBERS_SCHEMA } from "@/src/utils/schemas/groups";
 import GroupMembers, { GroupDetailsType } from "./GroupMembers";
 import { GROUP_ROLES_HEIRARCHY } from "@/src/utils/constants";
+import Link from "next/link";
 
 export type GroupStatusType = {
   [memberID: string]: { [statusID: string]: STATUS_SCHEMA };
@@ -31,17 +32,17 @@ export default function GroupStrengthSection({
   admin: boolean;
 }) {
   const [show, setShow] = useState(false);
-  var empty = true;
 
-  const keys = Object.keys(GroupStatusList);
+  // var empty = true;
+  // const keys = Object.keys(GroupStatusList);
 
-  for (var i = 0; i < keys.length; i++) {
-    const length = Object.keys(GroupStatusList[keys[i]]).length;
-    if (length !== 0) {
-      empty = false;
-      break;
-    }
-  }
+  // for (var i = 0; i < keys.length; i++) {
+  //   const length = Object.keys(GroupStatusList[keys[i]]).length;
+  //   if (length !== 0) {
+  //     empty = false;
+  //     break;
+  //   }
+  // }
 
   const totalStrength = Object.keys(membersList).length;
   const commandersStrength = Object.keys(membersList).filter(
@@ -76,6 +77,30 @@ export default function GroupStrengthSection({
       return statusList.length > 0;
     }
   ).length;
+
+  const activeStatuses = Object.keys(GroupStatusList).filter(
+    (memberID: string) => {
+      // check if member has active statuses
+      const activeMembers = Object.keys(GroupStatusList[memberID]).map(
+        (statusID: string) => {
+          const { endDate } = GroupStatusList[memberID][statusID];
+          const active = ActiveTimestamp(endDate);
+          return active;
+        }
+      );
+
+      if (activeMembers.length > 0) {
+        let flag = false;
+        activeMembers.forEach((active: boolean) => {
+          if (active) flag = true;
+        });
+        if (flag) return true;
+      }
+      return false;
+    }
+  );
+
+  const empty = activeStatuses.length === 0;
 
   return (
     <DefaultCard className="w-full flex flex-col items-start justify-start gap-2">
@@ -125,10 +150,11 @@ export default function GroupStrengthSection({
                 >
                   {empty ? (
                     <p className="text-sm text-custom-grey-text">
-                      Looks like nobody in this groups have statuses recorded.
+                      Great! Looks like nobody in this group currently have
+                      statuses.
                     </p>
                   ) : (
-                    Object.keys(GroupStatusList).map((memberID: string) => {
+                    activeStatuses.map((memberID: string) => {
                       const memberStatus = GroupStatusList[memberID];
                       const memberEmpty =
                         Object.keys(memberStatus).length === 0;
@@ -148,15 +174,15 @@ export default function GroupStrengthSection({
                                 const active = ActiveTimestamp(
                                   statusData.endDate
                                 );
-
-                                return (
-                                  <MemberStatusTab
-                                    key={statusData.statusID}
-                                    active={active}
-                                    memberID={memberID}
-                                    statusData={statusData}
-                                  />
-                                );
+                                if (active)
+                                  return (
+                                    <MemberStatusTab
+                                      key={statusData.statusID}
+                                      active={active}
+                                      memberID={memberID}
+                                      statusData={statusData}
+                                    />
+                                  );
                               }
                             )}
                           </div>
@@ -164,6 +190,12 @@ export default function GroupStrengthSection({
                     })
                   )}
                 </InnerContainer>
+                <Link
+                  href={`/groups/${groupID}/statuses`}
+                  className="text-sm underline text-custom-grey-text self-end hover:text-custom-primary duration-150"
+                >
+                  View all statuses
+                </Link>
               </>
             )}
           </div>

--- a/src/components/groups/custom/statuses/FullStatusList.tsx
+++ b/src/components/groups/custom/statuses/FullStatusList.tsx
@@ -1,0 +1,77 @@
+"use client";
+import HRow from "@/src/components/utils/HRow";
+import InnerContainer from "@/src/components/utils/InnerContainer";
+import { ActiveTimestamp } from "@/src/utils/getCurrentDate";
+import React from "react";
+import { twMerge } from "tailwind-merge";
+import MemberStatusTab from "../MemberStatusTab";
+import { GroupStatusType } from "../GroupStrengthSection";
+import useQueryObj from "@/src/hooks/useQueryObj";
+import QueryInput from "@/src/components/utils/QueryInput";
+import DefaultCard from "@/src/components/DefaultCard";
+
+export default function FullStatusList({
+  groupStatusList,
+}: {
+  groupStatusList: GroupStatusType;
+}) {
+  const { handleSearch, itemList, search } = useQueryObj({
+    obj: groupStatusList,
+  });
+
+  const empty = Object.keys(itemList).length === 0;
+
+  return (
+    <>
+      <DefaultCard className="w-full">
+        <QueryInput
+          className="m-0"
+          handleSearch={handleSearch}
+          placeholder="Search memberID"
+          search={search}
+        />
+      </DefaultCard>
+      <DefaultCard className="w-full">
+        <InnerContainer
+          className={twMerge(
+            "min-h-[40vh] overflow-visible",
+            empty &&
+              "grid place-items-center justify-center overflow-hidden p-4"
+          )}
+        >
+          {empty ? (
+            <p className="text-sm text-custom-grey-text">
+              Whoops, nothing here.
+            </p>
+          ) : (
+            Object.keys(itemList).map((memberID: string) => {
+              const memberStatus = itemList[memberID];
+              const memberEmpty = Object.keys(memberStatus).length === 0;
+              return (
+                <div
+                  key={memberID}
+                  className="w-full flex-col flex items-start justify-center"
+                >
+                  <h1 className="p-2 font-semibold text-sm">{memberID}</h1>
+                  <HRow className="my-0" />
+                  {Object.keys(memberStatus).map((statusID: string) => {
+                    const statusData = memberStatus[statusID];
+                    const active = ActiveTimestamp(statusData.endDate);
+                    return (
+                      <MemberStatusTab
+                        key={statusData.statusID}
+                        active={active}
+                        memberID={memberID}
+                        statusData={statusData}
+                      />
+                    );
+                  })}
+                </div>
+              );
+            })
+          )}
+        </InnerContainer>
+      </DefaultCard>
+    </>
+  );
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -78,6 +78,15 @@ export const BADGE_COLORS = {
 export const MAX_LENGTH = 30;
 
 export const VERSION_MAP = {
+  "0.4.0": {
+    version: "0.4.0",
+    title: "Statuses Viewing",
+    desc: "You are part of Social40's beginning. Feel free to provide your feedback.",
+    updates: [
+      "Only active statuses will be shown on the main group page",
+      "A link is available to view all past statuses of every member in the group",
+    ],
+  },
   "0.3.3": {
     version: "0.3.3",
     title: "Profile Pictures",


### PR DESCRIPTION
- only active statuses will be shown on the main group page
- a link is available to view all past statuses of every member in the group
- explicitly separate current statuses
- simplifies accounting of strength